### PR TITLE
Improve long chat performance by 2 - 3x

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
   sidekick-server:
     image: embernet/sidekick-server:latest
     ports:
-      - "127.0.0.1:8000:80"
+      - "127.0.0.1:8000:5000"
     env_file:
       - .env
     extra_hosts:

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -32,8 +32,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "PORT=8080 react-scripts start",
-    "start-container": "PORT=8081 react-scripts start",
+    "start": "SET PORT=8080 && react-scripts start",
+    "start-container": "SET PORT=8081 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/web_ui/src/Chat.js
+++ b/web_ui/src/Chat.js
@@ -1055,7 +1055,7 @@ const Chat = ({
                                 {
                                     markdownRenderingOn
                                     ?
-                                        <SidekickMarkdown  markdown={message.content}/>
+                                        <SidekickMarkdown markdown={message.content}/>
                                     :
                                         <Typography sx={{ whiteSpace: 'pre-wrap' }}>
                                             {message.content}

--- a/web_ui/src/SidekickMarkdown.js
+++ b/web_ui/src/SidekickMarkdown.js
@@ -7,8 +7,9 @@ import { useContext } from 'react';
 import { Card, Toolbar, Typography, Box, IconButton } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { SystemContext } from './SystemContext';
+import { memo } from 'react';
 
-const SidekickMarkdown = ({ markdown }) => {
+const SidekickMarkdown = memo(({ markdown }) => {
     const system = useContext(SystemContext);
 
     const renderMarkdown = (markdown) => {
@@ -61,6 +62,6 @@ const SidekickMarkdown = ({ markdown }) => {
     }
     const result = renderMarkdown(markdown);
     return (result);
-};
+});
 
 export default SidekickMarkdown;


### PR DESCRIPTION
- Memoizes `<SidekickMarkdown>` so that we don't pay the cost of re-rendering every single message's markdown on every keypress.
- This improved the "good performance" range of a chat in my local testing from ~1000 - 1500 tokens, to ~4.5k tokens.
- More wins could be found by not iterating through every previous message at all, but this would require a larger refactor.
- PR includes some other small fixes I had to make in order to get the app + server running locally.

Tagging @embernet.